### PR TITLE
Phase 2: performance (re-target to main)

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,9 +35,7 @@
     "react-syntax-highlighter": "^15.5.0",
     "redux": "^5.0.1",
     "rehype-katex": "^7.0.0",
-    "rehype-mermaid": "^2.0.1",
     "rehype-raw": "^7.0.0",
-    "remark": "^15.0.1",
     "remark-gfm": "^4.0.0",
     "remark-math": "^6.0.0"
   },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,16 +5,16 @@ import {Header} from "./components/Header";
 import {SettingsMenu} from "./components/SettingsMenu";
 import {FileViewer} from "./components/FileViewer";
 import {Alert} from "./components/Alert";
-import React, {createRef, useEffect, useRef, useState} from "react";
-import {editor} from "monaco-editor";
-import IStandaloneCodeEditor = editor.IStandaloneCodeEditor;
+import {useRef, useState} from "react";
+import type {editor} from "monaco-editor";
+type IStandaloneCodeEditor = editor.IStandaloneCodeEditor;
 import {throttle} from "./utils/throttle";
 import {useAppSelector} from "./store/hooks";
 import {store} from "./store/store";
 
 const App = ()=> {
     const [editor, setEditor] = useState<IStandaloneCodeEditor|undefined>(undefined)
-    const viewerRef = createRef<HTMLDivElement>()
+    const viewerRef = useRef<HTMLDivElement>(null)
 
     const doEditorScroll = ()=>{
        if(!store.getState().commonReducer.scrollSync){

--- a/src/components/InputField.tsx
+++ b/src/components/InputField.tsx
@@ -2,10 +2,12 @@ import {commonActions} from "../slices/CommonSlice";
 import {useAppDispatch, useAppSelector} from "../store/hooks";
 import Editor from "@monaco-editor/react";
 import {loadInitialFile} from "../hooks/loadInitialFile";
-import {FC, useEffect} from "react";
+import {FC, useEffect, useState} from "react";
 import {useDebounce} from "../hooks/DebounceHook";
-import {editor} from "monaco-editor";
-import IStandaloneCodeEditor = editor.IStandaloneCodeEditor;
+import {Spinner} from "./Spinner";
+import {setupMonaco} from "../utils/setupMonaco";
+import type {editor} from "monaco-editor";
+type IStandaloneCodeEditor = editor.IStandaloneCodeEditor;
 
 interface InputFieldProps {
     editor: IStandaloneCodeEditor|undefined,
@@ -16,10 +18,17 @@ export const InputField:FC<InputFieldProps> = ({editor, setEditor})=>{
     const currentFile = useAppSelector(state=>state.commonReducer.currentFile?.content)
     const dispatch = useAppDispatch()
     const text = useAppSelector(state=>state.commonReducer.text)
+    const [monacoReady, setMonacoReady] = useState(false)
 
     useDebounce(()=>{
         dispatch(commonActions.setText(text))
     },500,[text])
+
+    useEffect(()=>{
+        let active = true
+        setupMonaco().then(()=>{ if(active) setMonacoReady(true) })
+        return ()=>{ active = false }
+    },[])
 
     useEffect(()=>{
         if(currentFile===undefined){
@@ -27,6 +36,9 @@ export const InputField:FC<InputFieldProps> = ({editor, setEditor})=>{
         }
     },[])
 
+    if(!monacoReady){
+        return <Spinner/>
+    }
 
     return <div>{text!==undefined&& <Editor value={text} language="markdown" options={{wordWrap:'on'}}
                                             onMount={(editor, monaco) => {setEditor(editor)}}

--- a/src/components/MarkdownViewer.tsx
+++ b/src/components/MarkdownViewer.tsx
@@ -1,4 +1,4 @@
-import React, {FC, MutableRefObject, Ref, RefObject, useEffect} from 'react';
+import React, {FC, RefObject, useMemo} from 'react';
 import ReactMarkdown from 'react-markdown';
 import rehypeRaw from 'rehype-raw'
 import remarkGfm from "remark-gfm";
@@ -6,54 +6,59 @@ import remarkMath from "remark-math";
 import 'katex/dist/katex.min.css'
 import rehypeKatex from "rehype-katex";
 import {useAppSelector} from "../store/hooks";
-import {Prism as SyntaxHighlighter} from 'react-syntax-highlighter'
-import remarkMermaid from 'rehype-mermaid';
+import {PrismAsync as SyntaxHighlighter} from 'react-syntax-highlighter'
 import "../css/markdown.css"
-import { remark } from 'remark';
 import {Spinner} from "./Spinner";
+import {Mermaid} from "./Mermaid";
+import {getCodeLanguage} from "../utils/codeLanguage";
 
 interface MarkdownViewerProps {
     refObj: RefObject<HTMLDivElement>
 }
 
-export const MarkdownViewer:FC<MarkdownViewerProps> = ({refObj})=>{
-    const currentFile = useAppSelector(state=>state.commonReducer.currentFile?.content)
+// react-syntax-highlighter (PrismAsync) loads each language grammar on demand,
+// and mermaid is rendered via a lazily-imported component, so neither is bundled
+// into the eager path.
+const markdownComponents = {
+    code({className, children, ...props}: any) {
+        const language = getCodeLanguage(className)
+        const value = String(children).replace(/\n$/, '')
 
-    if(currentFile === undefined){
-        return <Spinner/>
+        if (language === 'mermaid') {
+            return <Mermaid chart={value}/>
+        }
+        if (language) {
+            return <SyntaxHighlighter language={language} PreTag="div">{value}</SyntaxHighlighter>
+        }
+        return <code className={className} {...props}>{children}</code>
     }
+}
 
-    const handle =  (node: any, error: string):any =>{
-        console.log(error)
-        console.log(node.position)
-        node.value=error
-        return node.value==="mermaid"?{type:"html",value:''}:node
+const remarkPlugins = [remarkMath, remarkGfm]
+const rehypePlugins = [rehypeKatex, rehypeRaw]
+
+const MarkdownViewerImpl: FC<MarkdownViewerProps> = ({refObj}) => {
+    const currentFile = useAppSelector(state => state.commonReducer.currentFile?.content)
+
+    // Components/plugin arrays are module constants, but memo keeps referential
+    // stability obvious and lets React.memo short-circuit unchanged renders.
+    const components = useMemo(() => markdownComponents, [])
+
+    if (currentFile === undefined) {
+        return <Spinner/>
     }
 
     return (
         <div className="overflow-y-scroll" ref={refObj}>
-        <ReactMarkdown className="max-h-100 grid-none border-gray-100 border-2 rounded-2xl pl-4 pt-2 pb-2 pr-4 relative print:col-span-2 print:inline print:w-auto print:h-auto print:overflow-visible print:break-after-page print:absolute print:border-none markdown-viewer"
-                       children={currentFile}
-                       components={{
-                            code({node,inlist, className, children, ...props}) {
-                               const match = /language-(\w+)/.exec(className || '')
-                               return !inlist && match ? (
-                                   <SyntaxHighlighter
-                                       children={String(children).replace(/\n$/, '') as string}
-                                       language={match[1]}
-                                       PreTag="div"
-                                   />
-                               ) : (
-                                   <code className={className} {...props}>
-                                       {children}
-                                   </code>
-                               )
-                           }
-                       }}
-                           remarkPlugins={[remarkMath, remarkGfm, [remarkMermaid, { onError : 'fallback', errorFallback:handle }]]}
-            rehypePlugins={[rehypeKatex,rehypeRaw]}
-        />
+            <ReactMarkdown
+                className="max-h-100 grid-none border-gray-100 border-2 rounded-2xl pl-4 pt-2 pb-2 pr-4 relative print:col-span-2 print:inline print:w-auto print:h-auto print:overflow-visible print:break-after-page print:absolute print:border-none markdown-viewer"
+                children={currentFile}
+                components={components}
+                remarkPlugins={remarkPlugins}
+                rehypePlugins={rehypePlugins}
+            />
         </div>)
-
 }
+
+export const MarkdownViewer = React.memo(MarkdownViewerImpl)
 export default MarkdownViewer

--- a/src/components/Mermaid.test.tsx
+++ b/src/components/Mermaid.test.tsx
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+
+const renderMock = vi.fn()
+const initializeMock = vi.fn()
+
+vi.mock('mermaid', () => ({
+    default: {
+        initialize: (...args: unknown[]) => initializeMock(...args),
+        render: (...args: unknown[]) => renderMock(...args),
+    },
+}))
+
+import { Mermaid } from './Mermaid'
+
+describe('Mermaid', () => {
+    it('renders the SVG produced by mermaid', async () => {
+        renderMock.mockResolvedValueOnce({ svg: '<svg data-testid="diagram">ok</svg>' })
+        render(<Mermaid chart="graph TD; A-->B" />)
+
+        await waitFor(() => {
+            expect(screen.getByTestId('mermaid').innerHTML).toContain('<svg')
+        })
+        expect(renderMock).toHaveBeenCalledWith(expect.any(String), 'graph TD; A-->B')
+    })
+
+    it('shows an error message when mermaid fails to parse', async () => {
+        renderMock.mockRejectedValueOnce(new Error('Parse error on line 1'))
+        render(<Mermaid chart="not a diagram" />)
+
+        await waitFor(() => {
+            expect(screen.getByTestId('mermaid-error')).toHaveTextContent('Parse error on line 1')
+        })
+    })
+})

--- a/src/components/Mermaid.tsx
+++ b/src/components/Mermaid.tsx
@@ -1,0 +1,43 @@
+import {FC, useEffect, useRef, useState} from "react";
+
+// mermaid is ~1.4MB; load it on demand the first time a diagram is rendered
+// and reuse the same instance afterwards.
+let mermaidPromise: Promise<typeof import("mermaid")["default"]> | null = null
+
+const loadMermaid = () => {
+    if (!mermaidPromise) {
+        mermaidPromise = import("mermaid").then(mod => {
+            mod.default.initialize({startOnLoad: false, theme: "default"})
+            return mod.default
+        })
+    }
+    return mermaidPromise
+}
+
+let diagramCounter = 0
+
+interface MermaidProps {
+    chart: string
+}
+
+export const Mermaid: FC<MermaidProps> = ({chart}) => {
+    const containerRef = useRef<HTMLDivElement>(null)
+    const [svg, setSvg] = useState<string>("")
+    const [error, setError] = useState<string | null>(null)
+
+    useEffect(() => {
+        let active = true
+        setError(null)
+        loadMermaid()
+            .then(mermaid => mermaid.render(`mermaid-diagram-${diagramCounter++}`, chart))
+            .then(({svg}) => { if (active) setSvg(svg) })
+            .catch((e: unknown) => { if (active) setError(e instanceof Error ? e.message : String(e)) })
+        return () => { active = false }
+    }, [chart])
+
+    if (error) {
+        return <pre className="text-red-600 text-sm whitespace-pre-wrap" data-testid="mermaid-error">{error}</pre>
+    }
+
+    return <div ref={containerRef} className="mermaid" data-testid="mermaid" dangerouslySetInnerHTML={{__html: svg}}/>
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -10,63 +10,27 @@ import {Spinner} from "./components/Spinner";
 import {I18nextProvider} from "react-i18next";
 import i18n from "./i18n/i18n";
 
+// App (and Monaco, which it sets up on mount) is only loaded for the editor route.
+const App = lazy(() => import("./App"));
 
+const AppPage = () => (
+    <Suspense fallback={<Spinner/>}>
+        <App/>
+    </Suspense>
+);
 
-const init = async () => {
-    const loader =  await import("@monaco-editor/loader");
-    const monaco = await import("monaco-editor")
-    const editorWorker = await import("monaco-editor/esm/vs/editor/editor.worker?worker")
-    const jsonWorker = await import("monaco-editor/esm/vs/language/json/json.worker?worker")
-    const cssWorker = await import("monaco-editor/esm/vs/language/css/css.worker?worker")
-    const htmlWorker = await import("monaco-editor/esm/vs/language/html/html.worker?worker")
-    const tsWorker = await import("monaco-editor/esm/vs/language/typescript/ts.worker?worker")
-
-    self.MonacoEnvironment = {
-        getWorker(_, label) {
-            if (label === "json") {
-                return new jsonWorker.default()
-            }
-            if (label === "css" || label === "scss" || label === "less") {
-                return new cssWorker.default()
-            }
-            if (label === "html" || label === "handlebars" || label === "razor") {
-                return new htmlWorker.default()
-            }
-            if (label === "typescript" || label === "javascript") {
-                return new tsWorker.default()
-            }
-            return new editorWorker.default()
-        }
-    }
-    loader.default.config({monaco});
-}
-
-init()
-    .then(()=> {
-
-        const App = lazy(() => import("./App"));
-
-        const AppPage = () => (
-            <Suspense fallback={<Spinner/>}>
-                <App/>
-            </Suspense>
-        );
-
-
-
-        ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
-        <React.StrictMode>
-            <I18nextProvider i18n={i18n}>
-                <Provider store={store}>
-                    <HashRouter basename={"/"}>
-                        <Routes>
-                            <Route path={"/app"} element={<AppPage/>}/>
-                            <Route path={"/privacy"} element={<PrivacyPolicy/>}/>
-                            <Route path={"/"} element={<WelcomeScreen/>}/>
-                        </Routes>
-                    </HashRouter>
-                </Provider>
-            </I18nextProvider>
-            </React.StrictMode>
-        )
-    })
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+    <React.StrictMode>
+        <I18nextProvider i18n={i18n}>
+            <Provider store={store}>
+                <HashRouter basename={"/"}>
+                    <Routes>
+                        <Route path={"/app"} element={<AppPage/>}/>
+                        <Route path={"/privacy"} element={<PrivacyPolicy/>}/>
+                        <Route path={"/"} element={<WelcomeScreen/>}/>
+                    </Routes>
+                </HashRouter>
+            </Provider>
+        </I18nextProvider>
+    </React.StrictMode>
+)

--- a/src/utils/codeLanguage.test.ts
+++ b/src/utils/codeLanguage.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest'
+import { getCodeLanguage, isMermaid } from './codeLanguage'
+
+describe('getCodeLanguage', () => {
+    it('extracts the language from a language-* class', () => {
+        expect(getCodeLanguage('language-ts')).toBe('ts')
+        expect(getCodeLanguage('foo language-python bar')).toBe('python')
+    })
+
+    it('returns null when there is no language class', () => {
+        expect(getCodeLanguage('')).toBeNull()
+        expect(getCodeLanguage(undefined)).toBeNull()
+        expect(getCodeLanguage('hljs')).toBeNull()
+    })
+})
+
+describe('isMermaid', () => {
+    it('is true only for language-mermaid', () => {
+        expect(isMermaid('language-mermaid')).toBe(true)
+        expect(isMermaid('language-js')).toBe(false)
+        expect(isMermaid(undefined)).toBe(false)
+    })
+})

--- a/src/utils/codeLanguage.ts
+++ b/src/utils/codeLanguage.ts
@@ -1,0 +1,9 @@
+// Extracts the language token from a react-markdown code element className
+// (e.g. "language-ts" -> "ts"). Returns null when no language is present.
+export const getCodeLanguage = (className?: string): string | null => {
+    const match = /language-(\w+)/.exec(className || '')
+    return match ? match[1] : null
+}
+
+export const isMermaid = (className?: string): boolean =>
+    getCodeLanguage(className) === 'mermaid'

--- a/src/utils/setupMonaco.ts
+++ b/src/utils/setupMonaco.ts
@@ -1,0 +1,42 @@
+// Loads the Monaco editor and its language workers, then points
+// @monaco-editor/react at the local monaco instance. This is deferred until the
+// editor is actually needed so non-editor routes (landing page, privacy page)
+// don't download ~3.5MB of editor code on first paint.
+let monacoSetupPromise: Promise<void> | null = null
+
+const doSetup = async (): Promise<void> => {
+    const loader = await import("@monaco-editor/loader")
+    const monaco = await import("monaco-editor")
+    const editorWorker = await import("monaco-editor/esm/vs/editor/editor.worker?worker")
+    const jsonWorker = await import("monaco-editor/esm/vs/language/json/json.worker?worker")
+    const cssWorker = await import("monaco-editor/esm/vs/language/css/css.worker?worker")
+    const htmlWorker = await import("monaco-editor/esm/vs/language/html/html.worker?worker")
+    const tsWorker = await import("monaco-editor/esm/vs/language/typescript/ts.worker?worker")
+
+    self.MonacoEnvironment = {
+        getWorker(_, label) {
+            if (label === "json") {
+                return new jsonWorker.default()
+            }
+            if (label === "css" || label === "scss" || label === "less") {
+                return new cssWorker.default()
+            }
+            if (label === "html" || label === "handlebars" || label === "razor") {
+                return new htmlWorker.default()
+            }
+            if (label === "typescript" || label === "javascript") {
+                return new tsWorker.default()
+            }
+            return new editorWorker.default()
+        }
+    }
+    loader.default.config({monaco})
+}
+
+// Idempotent: the setup work runs at most once per session.
+export const setupMonaco = (): Promise<void> => {
+    if (!monacoSetupPromise) {
+        monacoSetupPromise = doSetup()
+    }
+    return monacoSetupPromise
+}


### PR DESCRIPTION
Phase 2 (#55) was accidentally merged into the Phase 1 branch *after* Phase 1 had already merged to `main`, so the performance work never landed on `main`. This PR brings it in.

Single commit: defer Monaco out of bootstrap, lazy `<Mermaid>` component, `PrismAsync` highlighter, memoized preview, dropped unused `rehype-mermaid`/`remark`.

Landing-page initial JS: ~3.5MB (Monaco eager) → ~284KB. App chunk 1.66MB → 795KB. 28 tests pass, tsc clean, build succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)