### PR TITLE
Fix CI: deploy via modern GitHub Pages Actions flow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,11 +6,20 @@ on:
   pull_request:
     branches:
       - main
+
+# Permissions required by the GitHub Pages deployment (modern Actions flow).
 permissions:
-  contents: write
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment; don't cancel an in-progress production deploy.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
 jobs:
-  build-and-deploy:
-    concurrency: ci-${{ github.ref }}
+  build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎️
@@ -45,9 +54,24 @@ jobs:
           NODE_OPTIONS: --max-old-space-size=8192
         run: npm run build
 
-      # Deploy to GitHub Pages only on pushes to main (not on PRs).
-      - name: Deploy 🚀
+      - name: Setup Pages
         if: github.event_name == 'push'
-        uses: JamesIves/github-pages-deploy-action@v4
+        uses: actions/configure-pages@v5
+
+      - name: Upload Pages artifact
+        if: github.event_name == 'push'
+        uses: actions/upload-pages-artifact@v3
         with:
-          folder: dist
+          path: dist
+
+  deploy:
+    needs: build
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages 🚀
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,8 @@ on:
 permissions:
   contents: write
 jobs:
-  test:
+  build-and-deploy:
+    concurrency: ci-${{ github.ref }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎️
@@ -44,26 +45,9 @@ jobs:
           NODE_OPTIONS: --max-old-space-size=8192
         run: npm run build
 
-      - name: Upload build artifact
-        if: github.event_name == 'push'
-        uses: actions/upload-artifact@v4
-        with:
-          name: dist
-          path: dist
-
-  deploy:
-    needs: test
-    if: github.event_name == 'push'
-    concurrency: ci-${{ github.ref }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Download build artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: dist
-          path: dist
-
+      # Deploy to GitHub Pages only on pushes to main (not on PRs).
       - name: Deploy 🚀
+        if: github.event_name == 'push'
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           folder: dist


### PR DESCRIPTION
Fixes the failing GitHub Pages deployment and moves it to the modern GitHub Actions Pages flow.

## The bug
The Phase 3 workflow split into separate `test` + `deploy` jobs, but the deploy job only downloaded the build artifact and never checked out the repo — so the branch-push deploy action failed with `fatal: not in a git directory` (exit 128).

## The fix
Switched to the official GitHub Pages Actions flow (matching the repo's new "GitHub Actions" Pages source):
- **build** job: checkout → setup-node 20 → cache npm → install → `tsc --noEmit` → `npm test` → build → `actions/configure-pages` → `actions/upload-pages-artifact` (dist)
- **deploy** job: `actions/deploy-pages` via the `github-pages` environment
- `permissions: pages: write` + `id-token: write` (+ `contents: read`)
- `concurrency: pages` without cancelling in-progress deploys
- Pages/deploy steps run only on push to `main`; PRs still build, type-check, and test (no deploy)

> Note: requires the repository's Pages **Source** to be set to **GitHub Actions** (already done).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
