### PR TITLE
Fix preview scrolling and make the split divider grabbable

### DIFF
--- a/src/components/MarkdownViewer.test.tsx
+++ b/src/components/MarkdownViewer.test.tsx
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest'
+import { act } from '@testing-library/react'
+import { createRef } from 'react'
+import MarkdownViewer from './MarkdownViewer'
+import { renderWithStore } from '../test/renderWithStore'
+import { commonActions, File } from '../slices/CommonSlice'
+
+const file: File = { id: '1', name: 'a.md', content: '# Hi\n\ntext', lastOpened: '2025-01-01T00:00:00.000Z' }
+
+describe('MarkdownViewer', () => {
+    it('gives its scroll container a bounded height so the preview can scroll', () => {
+        const ref = createRef<HTMLDivElement>()
+        const { store, container } = renderWithStore(<MarkdownViewer refObj={ref} />)
+        act(() => { store.dispatch(commonActions.setCurrentFile(file)) })
+
+        const scroller = container.querySelector('.overflow-y-scroll')
+        expect(scroller).not.toBeNull()
+        // Without h-full the scroller grows to content height and never scrolls.
+        expect(scroller).toHaveClass('h-full')
+    })
+})

--- a/src/components/MarkdownViewer.tsx
+++ b/src/components/MarkdownViewer.tsx
@@ -49,9 +49,9 @@ const MarkdownViewerImpl: FC<MarkdownViewerProps> = ({refObj}) => {
     }
 
     return (
-        <div className="overflow-y-scroll" ref={refObj}>
+        <div className="h-full overflow-y-scroll print:h-auto print:overflow-visible" ref={refObj}>
             {/* react-markdown v10 dropped the className prop; style a wrapper instead. */}
-            <div className="max-h-100 grid-none border-gray-100 border-2 rounded-2xl pl-4 pt-2 pb-2 pr-4 relative print:col-span-2 print:inline print:w-auto print:h-auto print:overflow-visible print:break-after-page print:absolute print:border-none markdown-viewer">
+            <div className="min-h-full grid-none border-gray-100 border-2 rounded-2xl pl-4 pt-2 pb-2 pr-4 relative print:col-span-2 print:inline print:w-auto print:h-auto print:overflow-visible print:break-after-page print:absolute print:border-none markdown-viewer">
                 <ReactMarkdown
                     children={currentFile}
                     components={components}

--- a/src/components/SplitPane.tsx
+++ b/src/components/SplitPane.tsx
@@ -59,6 +59,8 @@ export const SplitPane: FC<SplitPaneProps> = ({storageKey, left, right}) => {
             <div className="min-w-0 h-full grow-0 shrink-0 print:w-full" style={{flexBasis: `${ratio * 100}%`}}>
                 {left}
             </div>
+            {/* Wide (12px) hit zone with a visible centred grip so the divider is
+                easy to grab; the handle highlights on hover/drag/focus. */}
             <div
                 role="separator"
                 aria-orientation="vertical"
@@ -69,8 +71,10 @@ export const SplitPane: FC<SplitPaneProps> = ({storageKey, left, right}) => {
                 data-testid="split-divider"
                 onMouseDown={(e) => { e.preventDefault(); setDragging(true) }}
                 onKeyDown={onKeyDown}
-                className="w-1.5 shrink-0 cursor-col-resize rounded-full bg-gray-200 hover:bg-blue-400 focus:bg-blue-400 focus:outline-hidden print:hidden"
-            />
+                className={`group flex w-3 shrink-0 cursor-col-resize select-none items-center justify-center focus:outline-hidden print:hidden ${dragging ? 'is-dragging' : ''}`}
+            >
+                <div className={`h-12 w-1 rounded-full bg-gray-300 transition-colors group-hover:bg-blue-400 group-focus:bg-blue-400 ${dragging ? 'bg-blue-500' : ''}`}/>
+            </div>
             <div className="min-w-0 h-full flex-1 print:w-full">
                 {right}
             </div>


### PR DESCRIPTION
Fixes two layout bugs reported on the deployed editor (debugged against the live site).

## 1. Preview pane couldn't scroll
**Root cause:** the `.overflow-y-scroll` container had no height constraint. Inside the flex split pane it expanded to its full content height (measured live: `clientHeight === scrollHeight === 4296px`), so there was nothing to scroll, and the tall content was clipped by the ancestor `overflow-hidden`.
**Fix:** give the scroll container `h-full` so it's bounded by the right pane, and replace the inner `max-h-100` (`max-height: 99%`, which capped the bordered frame) with `min-h-full`.

## 2. Divider was almost impossible to grab
The drag handler worked (verified programmatically), but the divider was only **6px** wide. Widened the hit zone to **12px** with a visible centred grip that highlights on hover/drag/focus.

## On the "space on the right"
Investigated at 1440 / 1920 / 2560px — the layout already fills the width edge-to-edge (no horizontal overflow, right pane is `flex-1`). The reported gap was a 50/50 split the user couldn't rebalance because the divider was nearly impossible to grab; making the divider grabbable resolves that.

## Verification
- 91 tests pass (added a regression test asserting the scroll container keeps `h-full`) · `tsc --noEmit` clean · `npm run build` succeeds
- Live Playwright check against the production build: `canScroll: true` (clientH 828 < scrollH 4520); divider hit zone is 12px and drags (50→35)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
