### PR TITLE
Add language label + copy button to code blocks

### DIFF
--- a/src/components/CodeBlock.test.tsx
+++ b/src/components/CodeBlock.test.tsx
@@ -1,0 +1,26 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, fireEvent, waitFor } from '@testing-library/react'
+import { CodeBlock } from './CodeBlock'
+import { renderWithStore } from '../test/renderWithStore'
+
+const writeText = vi.fn().mockResolvedValue(undefined)
+
+beforeEach(() => {
+    writeText.mockClear()
+    Object.assign(navigator, { clipboard: { writeText } })
+})
+
+describe('CodeBlock', () => {
+    it('shows the language label and a copy button', () => {
+        renderWithStore(<CodeBlock language="js" value="const x = 1" />)
+        expect(screen.getByText('js')).toBeInTheDocument()
+        expect(screen.getByRole('button', { name: 'Copy' })).toBeInTheDocument()
+    })
+
+    it('copies the raw code to the clipboard and confirms', async () => {
+        renderWithStore(<CodeBlock language="ts" value="let y = 2" />)
+        fireEvent.click(screen.getByRole('button', { name: 'Copy' }))
+        expect(writeText).toHaveBeenCalledWith('let y = 2')
+        await waitFor(() => expect(screen.getByRole('button', { name: 'Copied!' })).toBeInTheDocument())
+    })
+})

--- a/src/components/CodeBlock.tsx
+++ b/src/components/CodeBlock.tsx
@@ -1,0 +1,50 @@
+import {FC, useEffect, useRef, useState} from "react";
+import {PrismAsync as SyntaxHighlighter} from 'react-syntax-highlighter'
+import {oneLight} from 'react-syntax-highlighter/dist/esm/styles/prism'
+import {useTranslation} from "react-i18next";
+
+interface CodeBlockProps {
+    language: string
+    value: string
+}
+
+// A fenced code block with a header showing the language and a copy-to-clipboard
+// button (with a transient "Copied" confirmation).
+export const CodeBlock: FC<CodeBlockProps> = ({language, value}) => {
+    const {t} = useTranslation()
+    const [copied, setCopied] = useState(false)
+    const timeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
+
+    useEffect(() => () => clearTimeout(timeoutRef.current), [])
+
+    const copy = () => {
+        navigator.clipboard?.writeText(value).then(() => {
+            setCopied(true)
+            clearTimeout(timeoutRef.current)
+            timeoutRef.current = setTimeout(() => setCopied(false), 1500)
+        })
+    }
+
+    return (
+        <div className="my-3 overflow-hidden rounded-lg border border-gray-200">
+            <div className="flex items-center justify-between bg-gray-100 px-3 py-1 text-xs text-gray-500">
+                <span className="font-mono">{language}</span>
+                <button
+                    type="button"
+                    onClick={copy}
+                    className="rounded-sm px-2 py-0.5 hover:bg-gray-200"
+                >
+                    {copied ? t('copied') : t('copy')}
+                </button>
+            </div>
+            <SyntaxHighlighter
+                language={language}
+                style={oneLight}
+                PreTag="div"
+                customStyle={{margin: 0, borderRadius: 0, fontSize: '0.9em', background: '#fafafa'}}
+            >
+                {value}
+            </SyntaxHighlighter>
+        </div>
+    )
+}

--- a/src/components/MarkdownViewer.tsx
+++ b/src/components/MarkdownViewer.tsx
@@ -6,11 +6,10 @@ import remarkMath from "remark-math";
 import 'katex/dist/katex.min.css'
 import rehypeKatex from "rehype-katex";
 import {useAppSelector} from "../store/hooks";
-import {PrismAsync as SyntaxHighlighter} from 'react-syntax-highlighter'
-import {oneLight} from 'react-syntax-highlighter/dist/esm/styles/prism'
 import "../css/markdown.css"
 import {Spinner} from "./Spinner";
 import {Mermaid} from "./Mermaid";
+import {CodeBlock} from "./CodeBlock";
 import {getCodeLanguage} from "../utils/codeLanguage";
 
 interface MarkdownViewerProps {
@@ -29,16 +28,7 @@ const markdownComponents = {
             return <Mermaid chart={value}/>
         }
         if (language) {
-            return (
-                <SyntaxHighlighter
-                    language={language}
-                    style={oneLight}
-                    PreTag="div"
-                    customStyle={{margin: '0.75rem 0', borderRadius: '0.5rem', fontSize: '0.9em'}}
-                >
-                    {value}
-                </SyntaxHighlighter>
-            )
+            return <CodeBlock language={language} value={value}/>
         }
         return <code className={className} {...props}>{children}</code>
     }

--- a/src/i18n/json/de.json
+++ b/src/i18n/json/de.json
@@ -38,6 +38,8 @@
   "comment": "Kommentieren",
   "comment-explanation": "StackEdit ermöglicht Ihnen das Einfügen von Inline-Kommentaren und das Einbetten von Diskussionen mit anderen in Ihre Dateien, genauso wie Microsoft Word und Google Docs.",
   "content": "Inhalt",
+  "copy": "Kopieren",
+  "copied": "Kopiert!",
   "delete": "Löschen",
   "designed-web-writers": "Für Web-Entwickler:innen und Schreiber:innen designed",
   "device-privacy": "Alles wird auf deinem Gerät verarbeitet.",

--- a/src/i18n/json/en.json
+++ b/src/i18n/json/en.json
@@ -39,6 +39,8 @@
   "comment": "Comment",
   "comment-explanation": "StackEdit allows you to insert inline comments and embed collaborator discussions in your files, just as well as Microsoft Word and Google Docs.",
   "content": "Content",
+  "copy": "Copy",
+  "copied": "Copied!",
   "delete": "Delete",
   "designed-web-writers": "Designed for web writers",
   "device-privacy": "Everything is processed on device.",


### PR DESCRIPTION
Builds on the typography PR (#68) to make code blocks more useful and interactive. Stacked on `improve-preview-typography`.

## What
Fenced code blocks now render with:
- a header showing the **language**
- a **Copy** button that copies the raw code, with a transient "Copied!" confirmation

## How
- New `CodeBlock` component wrapping `PrismAsync` + `oneLight`; `MarkdownViewer` delegates fenced code to it
- Timeout cleared on unmount; `navigator.clipboard` optional-chained for safety
- i18n `copy` / `copied` (en + de)

## Verification
- 98 tests pass (added a `CodeBlock` test: label renders, copy writes the raw code and flips to "Copied!") · `tsc --noEmit` clean · `npm run build` succeeds
- Live Playwright check: header + button render, syntax colours apply, clicking Copy puts the code on the clipboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)
