### PR TITLE
Fix scroll sync: proportional + bidirectional

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,36 +8,57 @@ import {Alert} from "./components/Alert";
 import {SplitPane} from "./components/SplitPane";
 import {Outline} from "./components/Outline";
 import {CommandPalette} from "./components/CommandPalette";
-import {useRef, useState} from "react";
+import {useEffect, useRef, useState} from "react";
 import type {editor} from "monaco-editor";
 type IStandaloneCodeEditor = editor.IStandaloneCodeEditor;
-import {throttle} from "./utils/throttle";
 import {useAppSelector} from "./store/hooks";
 import {store} from "./store/store";
+import {proportionalScrollTop} from "./utils/scrollSync";
 
 const App = ()=> {
     const [editor, setEditor] = useState<IStandaloneCodeEditor|undefined>(undefined)
     const viewerRef = useRef<HTMLDivElement>(null)
     const outlineOpen = useAppSelector(state=>state.commonReducer.outlineOpen)
+    // The preview only renders its scroll container once a file is loaded; track
+    // that so the scroll-sync effect re-runs and attaches its listeners then.
+    const previewReady = useAppSelector(state=>state.commonReducer.currentFile?.content !== undefined)
 
-    const doEditorScroll = ()=>{
-       if(!store.getState().commonReducer.scrollSync){
-           return
-       }
-        const contentInTopLine = editor?.getModel()?.getLineContent(Number(editor?.getVisibleRanges()[0].startLineNumber))
-        if(contentInTopLine && contentInTopLine.trim() === ""){
+    // Bidirectional, proportional scroll sync between the editor and the preview.
+    // Whichever pane the user scrolls drives the other; a lock prevents the
+    // programmatic scroll from echoing back into a feedback loop.
+    useEffect(()=>{
+        const preview = viewerRef.current
+        if(!editor || !preview){
             return
         }
+        let locked = false
+        const withLock = (apply:()=>void)=>{
+            locked = true
+            apply()
+            requestAnimationFrame(()=>{ locked = false })
+        }
+        const enabled = ()=> store.getState().commonReducer.scrollSync
 
-        const res = document.querySelector('[data-sourcepos^="'+editor?.getVisibleRanges()[0].startLineNumber+':1"'+"]")
+        const editorToPreview = ()=>{
+            if(locked || !enabled()){ return }
+            const editorMax = editor.getScrollHeight() - editor.getLayoutInfo().height
+            const previewMax = preview.scrollHeight - preview.clientHeight
+            withLock(()=>{ preview.scrollTop = proportionalScrollTop(editor.getScrollTop(), editorMax, previewMax) })
+        }
+        const previewToEditor = ()=>{
+            if(locked || !enabled()){ return }
+            const previewMax = preview.scrollHeight - preview.clientHeight
+            const editorMax = editor.getScrollHeight() - editor.getLayoutInfo().height
+            withLock(()=> editor.setScrollTop(proportionalScrollTop(preview.scrollTop, previewMax, editorMax)))
+        }
 
-        res?.scrollIntoView({behavior: "smooth", block: "center", inline: "center"})
-    }
-    const throttledEditorScroll = throttle(doEditorScroll, 100)
-
-    editor?.onDidScrollChange((e)=>{
-            throttledEditorScroll()
-    })
+        const disposable = editor.onDidScrollChange(editorToPreview)
+        preview.addEventListener('scroll', previewToEditor)
+        return ()=>{
+            disposable.dispose()
+            preview.removeEventListener('scroll', previewToEditor)
+        }
+    },[editor, previewReady])
 
   return (
       <div className="grid grid-rows-[auto_1fr] h-screen gap-2 print:h-auto print:grid-cols-none print:grid-rows-none">

--- a/src/utils/scrollSync.test.ts
+++ b/src/utils/scrollSync.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest'
+import { proportionalScrollTop } from './scrollSync'
+
+describe('proportionalScrollTop', () => {
+    it('maps the source scroll fraction onto the target range', () => {
+        // halfway down a 1000px source range -> halfway down a 400px target range
+        expect(proportionalScrollTop(500, 1000, 400)).toBe(200)
+    })
+
+    it('maps top to top and bottom to bottom', () => {
+        expect(proportionalScrollTop(0, 1000, 400)).toBe(0)
+        expect(proportionalScrollTop(1000, 1000, 400)).toBe(400)
+    })
+
+    it('returns 0 when the source cannot scroll', () => {
+        expect(proportionalScrollTop(0, 0, 400)).toBe(0)
+        expect(proportionalScrollTop(50, -10, 400)).toBe(0)
+    })
+
+    it('clamps the result to the target range', () => {
+        expect(proportionalScrollTop(2000, 1000, 400)).toBe(400)
+    })
+})

--- a/src/utils/scrollSync.ts
+++ b/src/utils/scrollSync.ts
@@ -1,0 +1,15 @@
+// Maps a scroll position from a source scrollable region onto a target one by
+// preserving the scroll fraction. sourceMax/targetMax are (scrollHeight -
+// clientHeight) for each region.
+export const proportionalScrollTop = (
+    sourceTop: number,
+    sourceMax: number,
+    targetMax: number,
+): number => {
+    if (sourceMax <= 0) {
+        return 0
+    }
+    const fraction = sourceTop / sourceMax
+    const target = fraction * targetMax
+    return Math.max(0, Math.min(targetMax, target))
+}


### PR DESCRIPTION
Makes the **Scroll Sync** toggle actually work. Stacked on #66 (which makes the preview scrollable).

## The bug
Scroll Sync was a no-op: it queried `[data-sourcepos]` attributes that react-markdown v10 doesn't emit, and it re-registered the scroll listener on every render.

## The fix
Proportional, bidirectional sync from a single effect: whichever pane you scroll moves the other to the same scroll fraction. A `requestAnimationFrame` lock stops the programmatic scroll from echoing into a feedback loop. The effect also keys on `previewReady` because the preview shows a Spinner (no scroll container) until a file loads.

- `proportionalScrollTop()` pure helper (unit-tested: fraction mapping, no-scroll-range, clamping)
- Listeners attached once and disposed on cleanup; live `scrollSync` state read per event

## Verification
- 95 tests pass · `tsc --noEmit` clean · `npm run build` succeeds
- Live Playwright check: enabling sync + scrolling the editor to the bottom drives the preview to the bottom (3968/3968); scrolling the preview up drives the editor back toward the top

🤖 Generated with [Claude Code](https://claude.com/claude-code)
